### PR TITLE
Fix issues with lizard executable logic

### DIFF
--- a/lib/fastlane/plugin/lizard/actions/lizard_action.rb
+++ b/lib/fastlane/plugin/lizard/actions/lizard_action.rb
@@ -2,8 +2,12 @@ module Fastlane
   module Actions
     class LizardAction < Action
       def self.run(params)
-        if `which lizard`.to_s.empty?
+        if params[:executable].nil? && `which lizard`.to_s.empty?
           UI.user_error!("You have to install lizard using `[sudo] pip install lizard` or specify the executable path with the `:executable` option.")
+        end
+
+        if params[:executable] && !File.exist?(params[:executable])
+          UI.user_error!("The custom executable at '#{params[:executable]}' does not exist.")
         end
 
         command = forming_command(params)
@@ -24,7 +28,6 @@ module Fastlane
         command = []
         command << 'lizard' unless params[:executable]
         command << "python #{params[:executable]}" if params[:executable]
-        command << params[:source_folder].to_s if params[:source_folder]
         command << params[:language].split(",").map { |l| "-l #{l.strip}" }.join(" ") if params[:language]
         command << "--#{params[:export_type]}" if params[:export_type]
         command << "-C #{params[:ccn]}" if params[:ccn] # stands for cyclomatic complexity number
@@ -36,6 +39,7 @@ module Fastlane
         command << "-E #{params[:extensions]}" if params[:extensions]
         command << "-s #{params[:sorting]}" if params[:sorting]
         command << "-W #{params[:whitelist]}" if params[:whitelist]
+        command << params[:source_folder].to_s if params[:source_folder]
         command << "> #{params[:report_file].shellescape}" if params[:report_file]
 
         return command

--- a/spec/lizard_spec.rb
+++ b/spec/lizard_spec.rb
@@ -17,15 +17,27 @@ describe Fastlane::Actions::LizardAction do
 
         expect(result).to eq("lizard -l swift")
       end
+    end
 
-      it 'custom executable default as swift' do
+    context "when specify custom executable" do
+      it "uses custom executable" do
         result = Fastlane::FastFile.new.parse("lane :test do
           lizard(
-            executable: 'lizard/lizard.py'
+            executable: '../spec/fixtures/lizard.py'
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("python lizard/lizard.py -l swift")
+        expect(result).to eq("python ../spec/fixtures/lizard.py -l swift")
+      end
+
+      it "should raise if custom executable does not exist" do
+        expect do
+          Fastlane::FastFile.new.parse("lane :test do
+            lizard(
+              executable: 'no/such/file/lizard.py'
+            )
+          end").runner.execute(:test)
+        end.to raise_error("The custom executable at 'no/such/file/lizard.py' does not exist.")
       end
     end
 
@@ -61,7 +73,7 @@ describe Fastlane::Actions::LizardAction do
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("lizard #{folder} -l swift")
+        expect(result).to eq("lizard -l swift #{folder}")
       end
     end
 


### PR DESCRIPTION
- Lizard executable expects the following:
  - lizard [options] [PATH or FILE] [PATH] ...
  - But current code puts PATH (source_directory) _before_ the options
- The check for 'which lizard' ignores 'params[:executable]' option