### PR TITLE
Add support for list of languages

### DIFF
--- a/lib/fastlane/plugin/lizard/actions/lizard_action.rb
+++ b/lib/fastlane/plugin/lizard/actions/lizard_action.rb
@@ -25,7 +25,7 @@ module Fastlane
         command << 'lizard' unless params[:executable]
         command << "python #{params[:executable]}" if params[:executable]
         command << params[:source_folder].to_s if params[:source_folder]
-        command << "-l #{params[:language]}" if params[:language]
+        command << params[:language].split(",").map { |l| "-l #{l.strip}" }.join(" ") if params[:language]
         command << "--#{params[:export_type]}" if params[:export_type]
         command << "-C #{params[:ccn]}" if params[:ccn] # stands for cyclomatic complexity number
         command << "-L #{params[:length]}" if params[:length]
@@ -81,7 +81,7 @@ module Fastlane
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :language,
                                        env_name: "FL_LIZARD_LANGUAGE",
-                                       description: "List the programming languages you want to analyze",
+                                       description: "List the programming languages you want to analyze, e.g. 'swift,objectivec'",
                                        default_value: "swift",
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :export_type,

--- a/spec/lizard_spec.rb
+++ b/spec/lizard_spec.rb
@@ -3,6 +3,8 @@ describe Fastlane::Actions::LizardAction do
     let(:output_file) { "lizard.result.json" }
     let(:folder) { "assets" }
     let(:language) { "java" }
+    let(:multiple_languages) { "  java, swift,objectivec" }
+    let(:expected_multiple_language_options) { "-l java -l swift -l objectivec" }
     let(:ccn) { 10 }
     let(:length) { 800 }
     let(:working_threads) { 3 }
@@ -72,6 +74,18 @@ describe Fastlane::Actions::LizardAction do
         end").runner.execute(:test)
 
         expect(result).to eq("lizard -l #{language}")
+      end
+    end
+
+    context "when specify multiple languages to scan" do
+      it "states all specified languages" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          lizard(
+            language: '#{multiple_languages}'
+          )
+        end").runner.execute(:test)
+
+        expect(result).to eq("lizard #{expected_multiple_language_options}")
       end
     end
 


### PR DESCRIPTION
Current code says "List languages", but will only use one `-l` flag.
This change adds simple parsing logic for comma-separated list of languages.
Ideally the FL_LIZARD_LANGUAGE option should be FL_LIZARD_LANGUAGE`S` and take an array rather than string.
But that would be a breaking change for all current plugin users.