### PR TITLE
Use correct lizard command when custom executable is provided

### DIFF
--- a/spec/fixtures/newer_lizard.py
+++ b/spec/fixtures/newer_lizard.py
@@ -1,2 +1,2 @@
 # Imitate "lizard.py --version" command by default.
-print("1.14.10") # Matches contents of version.rb.
+print("2.0.0")

--- a/spec/fixtures/outdated_lizard.py
+++ b/spec/fixtures/outdated_lizard.py
@@ -1,2 +1,2 @@
 # Imitate "lizard.py --version" command by default.
-print("1.14.10") # Matches contents of version.rb.
+print("1.0.0")

--- a/spec/lizard_spec.rb
+++ b/spec/lizard_spec.rb
@@ -8,6 +8,9 @@ describe Fastlane::Actions::LizardAction do
     let(:ccn) { 10 }
     let(:length) { 800 }
     let(:working_threads) { 3 }
+    let(:custom_executable) { "../spec/fixtures/lizard.py" }
+    let(:outdated_executable) { "../spec/fixtures/outdated_lizard.py" }
+    let(:newer_executable) { "../spec/fixtures/newer_lizard.py" }
 
     context "executable" do
       it "fails with invalid sourcemap path" do
@@ -19,6 +22,37 @@ describe Fastlane::Actions::LizardAction do
             )
           end").runner.execute(:test)
         end.to raise_error("The custom executable at '#{sourcemap_path}' does not exist.")
+      end
+    end
+
+    context "required version" do
+      it "should not raise if executable version is same as required" do
+        expect(FastlaneCore::UI).to_not(receive(:user_error!))
+        Fastlane::FastFile.new.parse("lane :test do
+          lizard(
+            executable: '#{custom_executable}'
+          )
+        end").runner.execute(:test)
+      end
+
+      it "should not raise if executable version is newer than required" do
+        expect(FastlaneCore::UI).to_not(receive(:user_error!))
+        Fastlane::FastFile.new.parse("lane :test do
+          lizard(
+            executable: '#{newer_executable}'
+          )
+        end").runner.execute(:test)
+      end
+
+      it "should raise if executable version is less than required" do
+        expect(FastlaneCore::UI).to receive(:user_error!).with(/Your lizard version .* is outdated, please upgrade to at least version .* and start your lane again\!/).and_call_original
+        expect do
+          Fastlane::FastFile.new.parse("lane :test do
+            lizard(
+              executable: '#{outdated_executable}'
+            )
+          end").runner.execute(:test)
+        end.to raise_error(/Your lizard version .* is outdated, please upgrade to at least version .* and start your lane again\!/)
       end
     end
 
@@ -36,11 +70,11 @@ describe Fastlane::Actions::LizardAction do
       it "uses custom executable" do
         result = Fastlane::FastFile.new.parse("lane :test do
           lizard(
-            executable: '../spec/fixtures/lizard.py'
+            executable: '#{custom_executable}'
           )
         end").runner.execute(:test)
 
-        expect(result).to eq("python ../spec/fixtures/lizard.py -l swift")
+        expect(result).to eq("python #{custom_executable} -l swift")
       end
 
       it "should raise if custom executable does not exist" do


### PR DESCRIPTION
Min required version checks always run using `lizard` command, which may not even be available.
If custom executable is specified, then this executable should be used instead.