### PR TITLE
Remove unnecessary gemspec, push version to v1.1.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,12 @@
 source 'https://rubygems.org'
 
 gem 'codecov', require: false
+gem 'rake'
+gem 'rspec'
+gem 'rspec_junit_formatter'
+gem 'rubocop'
+gem 'simplecov'
+
 gemspec
 
 plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')

--- a/fastlane-plugin-lizard.gemspec
+++ b/fastlane-plugin-lizard.gemspec
@@ -24,9 +24,4 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'bundler'
   spec.add_dependency 'fastlane'
   spec.add_dependency 'pry'
-  spec.add_dependency 'rake'
-  spec.add_dependency 'rspec'
-  spec.add_dependency 'rspec_junit_formatter'
-  spec.add_dependency 'rubocop'
-  spec.add_dependency 'simplecov'
 end

--- a/lib/fastlane/plugin/lizard/version.rb
+++ b/lib/fastlane/plugin/lizard/version.rb
@@ -1,6 +1,6 @@
 module Fastlane
   module Lizard
-    VERSION = "1.1.0"
+    VERSION = "1.1.1"
     CLI_VERSION = "1.14.10"
   end
 end


### PR DESCRIPTION
Rake, Rspec and robocop are just needed for CI, not for the plugin. this PR differentiates that