### PR TITLE
Improve error communication

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+codecov:
+  token: 9b033b7b-e22e-45e6-8aba-eccef3026c0e

--- a/lib/fastlane/plugin/lizard/actions/lizard_action.rb
+++ b/lib/fastlane/plugin/lizard/actions/lizard_action.rb
@@ -6,8 +6,12 @@ module Fastlane
           UI.user_error!("You have to install lizard using `[sudo] pip install lizard` or specify the executable path with the `:executable` option.")
         end
 
-        if params[:executable] && !File.exist?(params[:executable])
-          UI.user_error!("The custom executable at '#{params[:executable]}' does not exist.")
+        if params[:executable]
+          if !File.exist?(params[:executable])
+            UI.user_error!("The custom executable at '#{params[:executable]}' does not exist.")
+          elsif !File.file?(params[:executable])
+            UI.user_error!("You need to point to the executable to lizard.py file!")
+          end
         end
 
         lizard_command = params[:executable].nil? ? "lizard" : "python #{params[:executable]}"

--- a/spec/lizard_spec.rb
+++ b/spec/lizard_spec.rb
@@ -11,6 +11,7 @@ describe Fastlane::Actions::LizardAction do
     let(:custom_executable) { "../spec/fixtures/lizard.py" }
     let(:outdated_executable) { "../spec/fixtures/outdated_lizard.py" }
     let(:newer_executable) { "../spec/fixtures/newer_lizard.py" }
+    let(:wrong_executable) { "../spec/fixtures" }
 
     context "executable" do
       it "fails with invalid sourcemap path" do
@@ -42,6 +43,17 @@ describe Fastlane::Actions::LizardAction do
             executable: '#{newer_executable}'
           )
         end").runner.execute(:test)
+      end
+
+      it "should raise if executable is wrong" do
+        expect(FastlaneCore::UI).to receive(:user_error!).with(/You need to point to the executable to lizard.py file\!/).and_call_original
+        expect do
+          Fastlane::FastFile.new.parse("lane :test do
+            lizard(
+              executable: '#{wrong_executable}'
+            )
+          end").runner.execute(:test)
+        end.to raise_error(/You need to point to the executable to lizard.py file\!/)
       end
 
       it "should raise if executable version is less than required" do


### PR DESCRIPTION
A developer is mistaken that adding an executable is compulsory. This 
improved error message should help users of this plugin better.