### PR TITLE
Exclude pattern fix

### DIFF
--- a/lib/fastlane/plugin/lizard/actions/lizard_action.rb
+++ b/lib/fastlane/plugin/lizard/actions/lizard_action.rb
@@ -41,7 +41,7 @@ module Fastlane
         command << "-L #{params[:length]}" if params[:length]
         command << "-a #{params[:arguments]}" if params[:arguments]
         command << "-i #{params[:number]}" if params[:number]
-        command << params[:exclude].split(",").map { |x| "-x #{x.strip}" }.join(" ").to_s if params[:exclude]
+        command << params[:exclude].split(",").map { |x| "-x \"#{x.strip}\"" }.join(" ").to_s if params[:exclude]
         command << "-t #{params[:working_threads]}" if params[:working_threads]
         command << "-E #{params[:extensions]}" if params[:extensions]
         command << "-s #{params[:sorting]}" if params[:sorting]

--- a/lib/fastlane/plugin/lizard/version.rb
+++ b/lib/fastlane/plugin/lizard/version.rb
@@ -1,6 +1,6 @@
 module Fastlane
   module Lizard
-    VERSION = "1.3.0"
+    VERSION = "1.3.1"
     CLI_VERSION = "1.14.10"
   end
 end


### PR DESCRIPTION
Fix to issue: https://github.com/liaogz82/fastlane-plugin-lizard/issues/41

The lizard documentation explicitly states that we should add quotation marks to exclude patterns:
```
-x EXCLUDE, --exclude EXCLUDE
                      Exclude files that match this pattern. * matches
                      everything, ? matches any single character,
                      "./folder/*" exclude everything in the folder
                      recursively. Multiple patterns can be specified. Don't
                      forget to add "" around the pattern.
```

https://github.com/terryyin/lizard/blob/master/README.rst